### PR TITLE
Potential fix for code scanning alert no. 3: Missing CSRF middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ var express = require('express');
 var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
+var lusca = require('lusca');
 
 var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
@@ -31,7 +32,8 @@ app.use(session({
   store: new FileStore(fileStoreOptions),
   resave: true,
   saveUninitialized: true
-}))
+}));
+app.use(lusca.csrf());
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.engine('html', (path, data, cb) => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "morgan": "~1.9.1",
     "mysql": "^2.18.1",
     "sass": "^1.81.0",
-    "session-file-store": "^1.5.0"
+    "session-file-store": "^1.5.0",
+    "lusca": "^1.7.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-iniguez-visioli/lafleur/security/code-scanning/3](https://github.com/thomas-iniguez-visioli/lafleur/security/code-scanning/3)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides CSRF protection and can be easily integrated into the existing code. We will install the `lusca` package and use its CSRF middleware in the Express app.

1. Install the `lusca` package.
2. Require the `lusca` package in the `app.js` file.
3. Add the `lusca.csrf()` middleware to the Express app after the session middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
